### PR TITLE
corrijo typo

### DIFF
--- a/especificaciones.html
+++ b/especificaciones.html
@@ -111,7 +111,7 @@
 
                         <li>Mail (direcci&oacute;n de correo electr&oacute;nico, obligatorio, 35 caracteres). Valor por defecto: vac&iacute;o.</li>
 
-                        <li>Si ya se encuentra creando un nuevo contacto o editando uno existente, el sistema emite un mensaje informando que se perder&aacute;n los cambios.pciones: Guardar y cancelar</li>
+                        <li>Opciones: Guardar y cancelar</li>
                     </ul>
                 </td>
 


### PR DESCRIPTION
En la descripción del alta hay un error que complica un poco la lectura de la especificación.